### PR TITLE
Fix the issue when Status bar is not hidden

### DIFF
--- a/TouchDemo/ViewController.swift
+++ b/TouchDemo/ViewController.swift
@@ -43,7 +43,14 @@ class ViewController: UIViewController, UIGestureRecognizerDelegate {
         
         drawerView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
         scrollView.addSubview(drawerView)
-
+		
+		if #available(iOS 11.0, *) {
+			scrollView.contentInsetAdjustmentBehavior = .never
+		} else {
+			// Fallback on earlier versions
+			self.automaticallyAdjustsScrollViewInsets = false
+		}
+		
         let device = view.traitCollection.userInterfaceIdiom
         addDots(device == .pad ? 25 : 10, toView: canvasView)
         addDots(device == .pad ? 20 : 7, toView: drawerView.contentView)
@@ -73,10 +80,6 @@ class ViewController: UIViewController, UIGestureRecognizerDelegate {
             longPress.delegate = self
             dot.addGestureRecognizer(longPress)
         }
-    }
-
-    override var prefersStatusBarHidden : Bool {
-        return true
     }
     
     // MARK: - Layout


### PR DESCRIPTION
When the status bar is not hidden, the `drawerView` appear after the status bar, and you found a small space between `drawerView` and the top edge of screen. By adding `scrollView.contentInsetAdjustmentBehavior = .never` line in `viewDidLoad()` for iOS 11 and `self.automaticallyAdjustsScrollViewInsets = false` for apps before iOS 11 this issue will be fix.